### PR TITLE
add search functionality to leaderboard

### DIFF
--- a/services/client/src/components/LeaderboardTable.tsx
+++ b/services/client/src/components/LeaderboardTable.tsx
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-import React from "react";
+import React, { useState } from "react";
 import { LeaderboardEntry } from "hooks/useLeaderboard";
 import { formatTime } from "lib/utils";
 import { gameDurationSeconds } from "lib/config";
@@ -18,17 +18,35 @@ type Props = {
 };
 
 const LeaderboardTable = ({ data }: Props) => {
+  const [nameFilter, setNameFilter] = useState("");
+
   const filteredData = data
     .filter((entry) => entry.health > 0 && entry.time < gameDurationSeconds)
+    .filter((entry) =>
+      entry.player.toLowerCase().includes(nameFilter.toLowerCase())
+    )
     .slice(0, 5);
 
   return (
     <>
-      <div>
-        <h1 className="text-gray-50 text-5xl">Leaderboard</h1>
-        <h2 className="text-orange text-xl my-2">
-          Open Liberty - Space Rover Mission
-        </h2>
+      <div className="flex flex-row justify-between items-end my-2">
+        <div>
+          <h1 className="text-gray-50 text-5xl">Leaderboard</h1>
+          <h2 className="text-orange text-xl mt-2">
+            Open Liberty - Space Rover Mission
+          </h2>
+        </div>
+        <div>
+          <input
+            className="px-5 py-3 rounded-md"
+            type="text"
+            autoComplete="false"
+            autoCorrect="false"
+            spellCheck="false"
+            placeholder="Filter by player name"
+            onChange={(e) => setNameFilter(e.target.value)}
+          />
+        </div>
       </div>
       <table className="w-full rounded-md overflow-hidden text-center text-xl">
         <thead className="bg-green">
@@ -52,6 +70,11 @@ const LeaderboardTable = ({ data }: Props) => {
           ))}
         </tbody>
       </table>
+      {filteredData.length === 0 && (
+        <div className="text-center text-xl text-gray-200 py-5">
+          No players to show
+        </div>
+      )}
     </>
   );
 };


### PR DESCRIPTION
for #65 

added a new search box on the top right of the leaderboard table. searches are case insensitive and will return all results which contain the search string (doesn't matter if search string matches on the start, end, or middle of the player name).

**no search:**
![image](https://user-images.githubusercontent.com/33457590/168381945-de0e72f0-0569-4fc2-95a1-1c86923e1975.png)

**search for players with the letter o in their name:**
![image](https://user-images.githubusercontent.com/33457590/168382360-835ba7ad-b1b6-4c20-b953-6ec36a34b297.png)

**show all of jimmy's results**
![image](https://user-images.githubusercontent.com/33457590/168382404-921e22c6-c330-4ed7-b82d-aa0bd26f48f3.png)

**no matches**
![image](https://user-images.githubusercontent.com/33457590/168382460-802da27e-74b1-42ae-bac9-bc87a17e0f7b.png)
