### PR TITLE
add a toggle to show failures on leaderboard page

### DIFF
--- a/services/client/src/components/LeaderboardTable.tsx
+++ b/services/client/src/components/LeaderboardTable.tsx
@@ -93,7 +93,7 @@ const LeaderboardTable = ({ data }: Props) => {
                 checked={showFails}
                 onChange={(e) => setShowFails(e.target.checked)}
               />
-              Show fails
+              Show failed missions
             </label>
           </div>
           <div className="flex flex-row items-center">

--- a/services/client/src/components/PlacementDisplay.tsx
+++ b/services/client/src/components/PlacementDisplay.tsx
@@ -11,13 +11,12 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { LeaderboardEntry } from "hooks/useLeaderboard";
-import { formatTime } from "lib/utils";
-import { gameDurationSeconds } from "lib/config";
+import { formatTime, playerFinished } from "lib/utils";
 
 type Props = LeaderboardEntry;
 
 const PlacementDisplay = ({ rank, player, time, health, score }: Props) => {
-  const success = health > 0 && time < gameDurationSeconds;
+  const success = playerFinished(health, time);
 
   return (
     <div className="text-gray-50 text-center pt-5 pb-10">

--- a/services/client/src/lib/utils.ts
+++ b/services/client/src/lib/utils.ts
@@ -8,6 +8,8 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+import { gameDurationSeconds } from "./config"; 
+
 export const formatTime = (time: number) => {
   const seconds = time % 60;
   const minutes = Math.floor(time / 60);
@@ -17,3 +19,7 @@ export const formatTime = (time: number) => {
 
   return `${formattedMinutes}:${formattedSeconds}`;
 };
+
+export const playerFinished = (health: number, time: number) => {
+  return health > 0 && time < gameDurationSeconds;
+}

--- a/services/client/src/pages/LeaderboardPage.tsx
+++ b/services/client/src/pages/LeaderboardPage.tsx
@@ -17,7 +17,7 @@ import failureSoundFile from "assets/sounds/failure.wav";
 import useLeaderboard from "hooks/useLeaderboard";
 import PlacementDisplay from "components/PlacementDisplay";
 import LeaderboardTable from "components/LeaderboardTable";
-import { gameDurationSeconds } from "lib/config";
+import { playerFinished } from "lib/utils";
 
 const LeaderboardPage = () => {
   const [searchParams] = useSearchParams();
@@ -38,7 +38,7 @@ const LeaderboardPage = () => {
 
     const { health, time, rank } = placement;
 
-    if (health > 0 && time < gameDurationSeconds) {
+    if (playerFinished(health, time)) {
       if (rank <= 5) {
         playHighscore();
       } else {


### PR DESCRIPTION
for #85 

adds a toggle that reveals the failed results

**toggle off:**
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/33457590/171878551-2a24a684-d93d-4ba9-8949-26a667b66e85.png">

**toggle on (page 1 of 2):**
<img width="1669" alt="image" src="https://user-images.githubusercontent.com/33457590/171878600-e0d97188-a5dd-42cc-a408-78fb76c5f95a.png">

**toggle on (page 2 of 2):**
<img width="1671" alt="image" src="https://user-images.githubusercontent.com/33457590/171878642-80f079db-d70d-4038-ae77-3d040e927161.png">

