### PR TITLE
show rover battery percentage on game registration page

### DIFF
--- a/services/client/src/components/BatteryStatus.tsx
+++ b/services/client/src/components/BatteryStatus.tsx
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+import React from "react";
+
+type Props = {
+  batteryPercentage: number;
+};
+
+const BatteryStatus = ({ batteryPercentage }: Props) => {
+  let color;
+  if (batteryPercentage < 20) {
+    color = "bg-red-600";
+  } else if (batteryPercentage < 50) {
+    color = "bg-yellow-500";
+  } else {
+    color = "bg-green-600";
+  }
+
+  return (
+    <div className="flex justify-center">
+      <div className="bg-gray-200 w-64 rounded-md overflow-hidden">
+        <div
+          className={`py-2 ${color}`}
+          style={{ width: `${batteryPercentage >= 0 ? batteryPercentage : 0}%` }}
+        >
+          <p className="px-5 text-md overflow-visible whitespace-nowrap">
+            Rover battery: {batteryPercentage >= 0 ? batteryPercentage : "--"}%
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BatteryStatus;

--- a/services/client/src/hooks/useGame.ts
+++ b/services/client/src/hooks/useGame.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -41,6 +41,7 @@ enum Event {
   PlanetChange = "planetChange",
   End = "endGame",
   Error = "error",
+  Battery = "battery",
 }
 
 const MSG_DELMITER = "|";
@@ -58,6 +59,7 @@ const useGame = (gameSocketURL: string, durationInSeconds: number) => {
   const [gameMode, setGameMode] = useState("1");
   const [health, setHealth] = useState(100);
   const [score, setScore] = useState(0);
+  const [battery, setBattery] = useState(-1);
 
   const [error, setError] = useState("");
 
@@ -150,11 +152,14 @@ const useGame = (gameSocketURL: string, durationInSeconds: number) => {
           setError(data);
           setGameState(GameState.Error);
           break;
+        case Event.Battery:
+          setBattery(data);
+          break;
         default:
           console.log(`Received unknown event: ${event}`);
       }
     };
-  }, [socket, crashSound, scoreSound, timerSound, shortTimerSound, health, score]);
+  }, [socket, crashSound, scoreSound, timerSound, shortTimerSound, health, score, battery]);
 
   useEffect(() => {
     if (timeRemaining === 10) {
@@ -197,6 +202,7 @@ const useGame = (gameSocketURL: string, durationInSeconds: number) => {
     startGame,
     endGame,
     error,
+    battery,
   };
 };
 

--- a/services/client/src/pages/PlayPage.tsx
+++ b/services/client/src/pages/PlayPage.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@ import { Navigate } from "react-router-dom";
 import PlayerForm from "components/PlayerForm";
 import GameScreen from "components/GameScreen";
 import GameStateMessage from "components/GameStateMessage";
+import BatteryStatus from "components/BatteryStatus";
 import useGame, { GameState } from "hooks/useGame";
 import { gameSocketURL, gameDurationSeconds } from "lib/config";
 
@@ -27,6 +28,7 @@ const PlayPage = () => {
     score,
     startGame,
     error,
+    battery,
   } = useGame(gameSocketURL, gameDurationSeconds);
 
   switch (gameState) {
@@ -44,6 +46,9 @@ const PlayPage = () => {
           <GameStateMessage
             state={gameState}
             errorMessage={error}
+          />
+          <BatteryStatus
+            batteryPercentage={battery}
           />
         </div>
       );


### PR DESCRIPTION
for #129

added the battery status on the game registration page.

---

**full battery:**
![image](https://user-images.githubusercontent.com/33457590/228880971-033fd7c4-bcc5-461b-92bb-d619dfbc3fb5.png)

**>= 50% battery:**
![image](https://user-images.githubusercontent.com/33457590/228881175-7d274e3f-79e0-427e-b473-718964874350.png)

**>= 20% battery and < 50% battery**
![image](https://user-images.githubusercontent.com/33457590/228881323-8a07f165-b2a8-4837-8662-8255a047c541.png)

**>= 0% battery and < 20% battery**
![image](https://user-images.githubusercontent.com/33457590/228881909-54ec6407-5acf-4192-9d45-091faf906de2.png)

**0% battery**
![image](https://user-images.githubusercontent.com/33457590/228882065-22f06516-bf9c-4e31-b24c-ec34e83ac4a6.png)

**waiting for battery info**
![image](https://user-images.githubusercontent.com/33457590/228882297-667b1ca8-29da-4477-bfe3-d45b623ad344.png)



