### PR TITLE
center battery status text

### DIFF
--- a/services/client/src/components/BatteryStatus.tsx
+++ b/services/client/src/components/BatteryStatus.tsx
@@ -27,11 +27,14 @@ const BatteryStatus = ({ batteryPercentage }: Props) => {
   return (
     <div className="flex justify-center">
       <div className="bg-gray-200 w-64 rounded-md overflow-hidden">
-        <div
-          className={`py-2 ${color}`}
-          style={{ width: `${batteryPercentage >= 0 ? batteryPercentage : 0}%` }}
-        >
-          <p className="px-5 text-md overflow-visible whitespace-nowrap">
+        <div className="relative h-12 flex justify-center items-center">
+          <div
+            className={`absolute h-12 bottom-0 left-0 ${color}`}
+            style={{
+              width: `${batteryPercentage >= 0 ? batteryPercentage : 0}%`,
+            }}
+          ></div>
+          <p className="relative text-md">
             Rover battery: {batteryPercentage >= 0 ? batteryPercentage : "--"}%
           </p>
         </div>


### PR DESCRIPTION
for #129

center battery status text

**before:**
![image](https://user-images.githubusercontent.com/33457590/229156754-f66a750f-857f-4505-af12-eebf75af3582.png)

**after:**
![image](https://user-images.githubusercontent.com/33457590/229158085-c87057d6-74d3-44b7-9a1b-b3c806313e9c.png)



